### PR TITLE
Use matix in css

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
     "dbaeumer.vscode-eslint",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
-    "silvenon.mdx",
-    "streetsidesoftware.code-spell-checker"
+    "streetsidesoftware.code-spell-checker",
+    "unifiedjs.vscode-mdx"
   ]
 }

--- a/src/utils/styles.utils.ts
+++ b/src/utils/styles.utils.ts
@@ -5,7 +5,7 @@ export const getTransformStyles = (
   y: number,
   scale: number,
 ): string => {
-  return `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  return `matrix(${scale}, 0,0, ${scale}, ${x}, ${y})`;
 };
 
 export const getCenterPosition = (


### PR DESCRIPTION
Use the CSS function matrix() instead of translate3d() because this fixes a scaling issue in Safari.

Original pull request from forked source: https://github.com/prc5/react-zoom-pan-pinch/pull/287.

Closes #53 