### PR TITLE
Include dist folder when publishing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "pronestor",
     "pronestoraps",
     "storysource",
+    "svgr",
     "syncyarnlock"
   ],
   "editor.codeActionsOnSave": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version 2.4.1
+
+- Include the dist folder in the npm package - version 2.4.0 is broken.
+
 ## Version 2.4.0
 
 - Use the CSS matrix() function instead of translate3d() because this fixes a scaling issue in Safari. More information in the original [pull request #287 for prc5/react-zoom-pan-pinch](https://github.com/prc5/react-zoom-pan-pinch/pull/287).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "rollup --config",
     "check-formatting": "prettier --check \"(.storybook|src)/**/*.+(js|json|ts|tsx)\" \"*.+(js|json|ts|tsx)\"",
     "check-linting": "eslint src/ --ext .js,.jsx,.tsx,.ts --format unix",
+    "prepublishOnly": "npm run build",
     "start": "start-storybook --port 6006",
     "update-dependencies": "yarn upgrade && npx syncyarnlock --keepPrefix --save && yarn install"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pronestor/react-zoom-pan-pinch",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "React package for zooming, panning and pinching html elements in an easy way.",
   "author": "Pronestor",
   "license": "MIT",

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -4,4 +4,4 @@ declare module "*.css" {
   export default content;
 }
 
-type SvgrComponent = React.StatelessComponent<React.SVGAttributes<SVGElement>>;
+type SvgrComponent = React.FunctionComponent<React.SVGAttributes<SVGElement>>;


### PR DESCRIPTION
Use `npmpublishOnly` to ensure that the package is built before publishing.