### PR TITLE
Use matrix3d() for transform

### DIFF
--- a/src/utils/styles.utils.ts
+++ b/src/utils/styles.utils.ts
@@ -5,7 +5,15 @@ export const getTransformStyles = (
   y: number,
   scale: number,
 ): string => {
-  return `matrix(${scale}, 0,0, ${scale}, ${x}, ${y})`;
+  // The shorthand for matrix does not work for Safari hence the need to explicitly use matrix3d
+  // Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/matrix
+  const a = scale;
+  const b = 0;
+  const c = 0;
+  const d = scale;
+  const tx = x;
+  const ty = y;
+  return `matrix3d(${a}, ${b}, 0, 0, ${c}, ${d}, 0, 0, 0, 0, 1, 0, ${tx}, ${ty}, 0, 1)`;
 };
 
 export const getCenterPosition = (


### PR DESCRIPTION
Refer to https://github.com/hueyyeng/simple-react-lightbox/issues/6 for more details

Previously a forked library I'm using uses https://github.com/prc5/react-zoom-pan-pinch and I saw this forked repo contains new fixes and actively maintained. So I opted to point the dependencies to this one and all is good except when I noticed the panning and zooming performance is choppy on iPad Pro.

Since the original implementation uses `translate3d()` and that has their own Safari issues, I saw you change it to use `matrix()` that fixes those issues but it resulted in the choppy performance I'm encountering on iPad Pro. Strangely the panning and zooming is acceptable on Safari desktop on MBP 2021 model...

I already tested using `matrix3d()` and it resolves the choppy issue on the iPad Pro. Also did sanity test on Chrome Android and Firefox Nightly Android and no issue too.